### PR TITLE
Fixed ?DATA syntax issue

### DIFF
--- a/src/eqc_dot.erl
+++ b/src/eqc_dot.erl
@@ -9,7 +9,7 @@
                        {workers,[]},
                        {command_timeout,{var,command_timeout}},
                        {async_timeout,{var,async_timeout}},
-                       {meta_cmd_stack,[]}]}},
+                       {meta_cmd_stack,[]}]},
                {set,{var,1},
                 {call,wiggle_eqc,connect,
                  [user1,"http://192.168.1.41"],


### PR DESCRIPTION
Fix for the following issue:

```
==> fqc (compile)
Compiling src/eqc_dot.erl failed:
src/eqc_dot.erl:135: syntax error before: '}'
src/eqc_dot.erl:3: function example_data/0 undefined
ERROR: compile failed while processing /home/fredrik/git/pubsub-control/src/pubsub/mx/deps/fqc: rebar_abort
```
